### PR TITLE
Allow kitchen motion script in Day mode

### DIFF
--- a/kitchen_motion(1).py
+++ b/kitchen_motion(1).py
@@ -19,7 +19,7 @@ MOTION_1      = "binary_sensor.aqara_motion_sensor_p1_occupancy"
 MOTION_2      = "binary_sensor.kitchen_iris_frig_occupancy"
 HOME_STATE_PRIMARY = "pyscript.home_state"
 HOME_STATE_FALLBACK = "input_select.home_state"
-ALLOWED_MODES = {"Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
+ALLOWED_MODES = {"Day", "Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
 
 # ===== Behavior knobs =====
 CLEAR_DEBOUNCE_SEC = 5

--- a/kitchen_motion.py
+++ b/kitchen_motion.py
@@ -19,7 +19,7 @@ MOTION_1      = "binary_sensor.aqara_motion_sensor_p1_occupancy"
 MOTION_2      = "binary_sensor.kitchen_iris_frig_occupancy"
 HOME_STATE_PRIMARY = "pyscript.home_state"
 HOME_STATE_FALLBACK = "input_select.home_state"
-ALLOWED_MODES = {"Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
+ALLOWED_MODES = {"Day", "Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
 
 # ===== Behavior knobs =====
 CLEAR_DEBOUNCE_SEC = 5


### PR DESCRIPTION
## Summary
- allow the kitchen motion automation to run while the home state is Day so motion can light the room

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8ab10270832cbe3a031ac2d868b1