### PR TITLE
Clarify kitchen night hold guard

### DIFF
--- a/kitchen_motion(1).py
+++ b/kitchen_motion(1).py
@@ -19,18 +19,32 @@ MOTION_1      = "binary_sensor.aqara_motion_sensor_p1_occupancy"
 MOTION_2      = "binary_sensor.kitchen_iris_frig_occupancy"
 HOME_STATE_PRIMARY = "pyscript.home_state"
 HOME_STATE_FALLBACK = "input_select.home_state"
-ALLOWED_MODES = {"Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
+ALLOWED_MODES = {"Day", "Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
+NIGHT_MAIN_RESUME_HOUR = 4
+NIGHT_MAIN_RESUME_MINUTE = 45
+
+# Brightness source toggles / sensors (follow controller priority stack)
+RAMP_ACTIVE = "input_boolean.sleep_in_ramp_active"
+RAMP_BRIGHTNESS = "sensor.sleep_in_ramp_brightness"
+ADAPTIVE_LEARNING_ENABLED = "input_boolean.adaptive_learning_enabled"
+LEARNED_BRIGHTNESS = "sensor.learned_brightness_kitchen"
+ALL_ROOMS_USE_PYSCRIPT = "input_boolean.all_rooms_use_pyscript"
+PYSCRIPT_BRIGHTNESS = "pyscript.test_kitchen_brightness"
+INTELLIGENT_LIGHTING_ENABLED = "input_boolean.intelligent_lighting_enable"
+INTELLIGENT_BRIGHTNESS = "sensor.intelligent_brightness_kitchen"
 
 # ===== Behavior knobs =====
 CLEAR_DEBOUNCE_SEC = 5
 TEST_BYPASS_MODE   = False       # set True to ignore mode gating while testing
 
-# Per-mode brightness for the main lights when motion turns them on
-MAIN_BRIGHTNESS = {
-    "Evening": 60,          # comfortable brightness for Evening
-    "Night":  10,           # very low at Night (BUT BLOCKED - see below)
-    "Early Morning": 35,    # soft pre-dawn level
+# Fallback brightness for the main lights when upstream sources are unavailable
+FALLBACK_BRIGHTNESS = {
+    "Day": 70,            # matches controller fallback for Day target brightness
+    "Evening": 60,        # comfortable brightness for Evening
+    "Night": 10,          # only used after the 04:45 resume guard while still Night
+    "Early Morning": 35,  # soft pre-dawn level
 }
+FALLBACK_DEFAULT_BRIGHTNESS = 60
 # Turn mains off when motion clears?
 TURN_MAIN_OFF_ON_CLEAR = True
 # ===========================
@@ -79,6 +93,90 @@ def _light_off(entity_id: str):
 def _any_motion_active() -> bool:
     return (_state(MOTION_1) == "on") or (_state(MOTION_2) == "on")
 
+
+def _clamp_pct(value) -> int | None:
+    try:
+        pct = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    return max(1, min(100, pct))
+
+
+def _fallback_brightness_for(mode: str) -> int:
+    return FALLBACK_BRIGHTNESS.get(mode, FALLBACK_DEFAULT_BRIGHTNESS)
+
+
+def _resolve_kitchen_brightness(home_mode: str) -> int:
+    """Resolve kitchen brightness using controller priority stack."""
+
+    invalid = {None, "", "unknown", "unavailable"}
+
+    try:
+        if _state(RAMP_ACTIVE) == "on":
+            ramp = _state(RAMP_BRIGHTNESS)
+            if ramp not in invalid:
+                val = _clamp_pct(ramp)
+                if val is not None:
+                    _info(f"Brightness source: Morning Ramp ({val}%)")
+                    return val
+
+        if _state(ADAPTIVE_LEARNING_ENABLED) == "on":
+            learned = _state(LEARNED_BRIGHTNESS)
+            if learned not in invalid:
+                using_learned = False
+                try:
+                    attrs = state.getattr(LEARNED_BRIGHTNESS) or {}
+                    using_learned = bool(attrs.get("using_learned"))
+                except Exception:
+                    using_learned = False
+                if using_learned:
+                    val = _clamp_pct(learned)
+                    if val is not None:
+                        _info(f"Brightness source: Adaptive Learning ({val}%)")
+                        return val
+
+        if _state(ALL_ROOMS_USE_PYSCRIPT) == "on":
+            pys_val = _state(PYSCRIPT_BRIGHTNESS)
+            if pys_val not in invalid:
+                val = _clamp_pct(pys_val)
+                if val is not None:
+                    _info(f"Brightness source: PyScript Engine ({val}%)")
+                    return val
+
+        if _state(INTELLIGENT_LIGHTING_ENABLED) == "on":
+            intelligent = _state(INTELLIGENT_BRIGHTNESS)
+            if intelligent not in invalid:
+                val = _clamp_pct(intelligent)
+                if val is not None:
+                    _info(f"Brightness source: Intelligent System ({val}%)")
+                    return val
+
+    except Exception as exc:
+        _warn(f"Brightness resolution failed: {exc}")
+
+    fallback = _fallback_brightness_for(home_mode)
+    label = f"Fallback {home_mode}" if home_mode in FALLBACK_BRIGHTNESS else "Fallback Default"
+    _info(f"Brightness source: {label} ({fallback}%)")
+    return fallback
+
+
+def _night_mains_window_active(now=None) -> bool:
+    """Return True if mains may run while home state is Night."""
+    if now is None:
+        now = datetime.now()
+
+    hour = now.hour
+    minute = now.minute
+
+    if hour < NIGHT_MAIN_RESUME_HOUR:
+        return False
+    if hour == NIGHT_MAIN_RESUME_HOUR and minute < NIGHT_MAIN_RESUME_MINUTE:
+        return False
+    if hour >= 12:
+        return False
+
+    return True
+
 # --- core behavior ---
 def _apply_for_motion(active: bool, reason: str):
     hs = _home_state()
@@ -88,26 +186,33 @@ def _apply_for_motion(active: bool, reason: str):
 
     _info(f"APPLY motion_active={active} mode={hs} reason={reason}")
 
+    now = datetime.now()
+    night_mode = hs == "Night"
+    night_hold_active = night_mode and not _night_mains_window_active(now)
+
     if active:
         # WLEDs on preset night-100
         _set_preset(SINK_PRESET, "night-100")
         _set_preset(FRIDGE_PRESET, "night-100")
 
-        # Main lights ON - BUT NOT IN NIGHT MODE
-        if hs != "Night":
-            br = MAIN_BRIGHTNESS.get(hs, 50)
-            _light_on(KITCHEN_MAIN, brightness_pct=br)
+        if night_hold_active:
+            _info("SKIPPING main lights – Night mode hold active (pre-04:45)")
         else:
-            _info(f"SKIPPING main lights - Night mode (WLED only)")
+            if night_mode:
+                _info("Night resume window reached (>=04:45) – turning mains on")
+            br = _resolve_kitchen_brightness(hs if not night_mode else "Night")
+            _light_on(KITCHEN_MAIN, brightness_pct=br)
 
     else:
         # WLED behavior: sink OFF, fridge to night
         _light_off(SINK_LIGHT)
         _set_preset(FRIDGE_PRESET, "night")
 
-        # Main lights OFF if configured AND they were turned on (not in Night mode)
-        if TURN_MAIN_OFF_ON_CLEAR and hs != "Night":
-            _light_off(KITCHEN_MAIN)
+        if TURN_MAIN_OFF_ON_CLEAR:
+            if night_hold_active:
+                _info("Leaving main lights alone – Night hold still active")
+            else:
+                _light_off(KITCHEN_MAIN)
 
 # --- listeners (no YAML automation needed) ---
 @state_trigger(MOTION_1)
@@ -133,7 +238,7 @@ def kitchen_wled_smoke_test():
     _info("SMOKE: WLEDs -> night-100; mains on; then sink OFF, fridge -> night")
     _set_preset(SINK_PRESET, "night-100")
     _set_preset(FRIDGE_PRESET, "night-100")
-    _light_on(KITCHEN_MAIN, brightness_pct=MAIN_BRIGHTNESS.get("Evening", 60))
+    _light_on(KITCHEN_MAIN, brightness_pct=_fallback_brightness_for("Evening"))
     time.sleep(2)
     _light_off(SINK_LIGHT)
     _set_preset(FRIDGE_PRESET, "night")

--- a/kitchen_motion.py
+++ b/kitchen_motion.py
@@ -19,18 +19,32 @@ MOTION_1      = "binary_sensor.aqara_motion_sensor_p1_occupancy"
 MOTION_2      = "binary_sensor.kitchen_iris_frig_occupancy"
 HOME_STATE_PRIMARY = "pyscript.home_state"
 HOME_STATE_FALLBACK = "input_select.home_state"
-ALLOWED_MODES = {"Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
+ALLOWED_MODES = {"Day", "Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
+NIGHT_MAIN_RESUME_HOUR = 4
+NIGHT_MAIN_RESUME_MINUTE = 45
+
+# Brightness source toggles / sensors (follow controller priority stack)
+RAMP_ACTIVE = "input_boolean.sleep_in_ramp_active"
+RAMP_BRIGHTNESS = "sensor.sleep_in_ramp_brightness"
+ADAPTIVE_LEARNING_ENABLED = "input_boolean.adaptive_learning_enabled"
+LEARNED_BRIGHTNESS = "sensor.learned_brightness_kitchen"
+ALL_ROOMS_USE_PYSCRIPT = "input_boolean.all_rooms_use_pyscript"
+PYSCRIPT_BRIGHTNESS = "pyscript.test_kitchen_brightness"
+INTELLIGENT_LIGHTING_ENABLED = "input_boolean.intelligent_lighting_enable"
+INTELLIGENT_BRIGHTNESS = "sensor.intelligent_brightness_kitchen"
 
 # ===== Behavior knobs =====
 CLEAR_DEBOUNCE_SEC = 5
 TEST_BYPASS_MODE   = False       # set True to ignore mode gating while testing
 
-# Per-mode brightness for the main lights when motion turns them on
-MAIN_BRIGHTNESS = {
-    "Evening": 60,          # comfortable brightness for Evening
-    "Night":  10,           # very low at Night (BUT BLOCKED - see below)
-    "Early Morning": 35,    # soft pre-dawn level
+# Fallback brightness for the main lights when upstream sources are unavailable
+FALLBACK_BRIGHTNESS = {
+    "Day": 70,            # matches controller fallback for Day target brightness
+    "Evening": 60,        # comfortable brightness for Evening
+    "Night": 10,          # only used after the 04:45 resume guard while still Night
+    "Early Morning": 35,  # soft pre-dawn level
 }
+FALLBACK_DEFAULT_BRIGHTNESS = 60
 # Turn mains off when motion clears?
 TURN_MAIN_OFF_ON_CLEAR = True
 # ===========================
@@ -79,6 +93,91 @@ def _light_off(entity_id: str):
 def _any_motion_active() -> bool:
     return (_state(MOTION_1) == "on") or (_state(MOTION_2) == "on")
 
+
+def _clamp_pct(value) -> int | None:
+    try:
+        pct = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    return max(1, min(100, pct))
+
+
+def _fallback_brightness_for(mode: str) -> int:
+    return FALLBACK_BRIGHTNESS.get(mode, FALLBACK_DEFAULT_BRIGHTNESS)
+
+
+def _resolve_kitchen_brightness(home_mode: str) -> int:
+    """Resolve kitchen brightness using controller priority stack."""
+
+    invalid = {None, "", "unknown", "unavailable"}
+
+    try:
+        if _state(RAMP_ACTIVE) == "on":
+            ramp = _state(RAMP_BRIGHTNESS)
+            if ramp not in invalid:
+                val = _clamp_pct(ramp)
+                if val is not None:
+                    _info(f"Brightness source: Morning Ramp ({val}%)")
+                    return val
+
+        if _state(ADAPTIVE_LEARNING_ENABLED) == "on":
+            learned = _state(LEARNED_BRIGHTNESS)
+            if learned not in invalid:
+                using_learned = False
+                try:
+                    attrs = state.getattr(LEARNED_BRIGHTNESS) or {}
+                    using_learned = bool(attrs.get("using_learned"))
+                except Exception:
+                    using_learned = False
+                if using_learned:
+                    val = _clamp_pct(learned)
+                    if val is not None:
+                        _info(f"Brightness source: Adaptive Learning ({val}%)")
+                        return val
+
+        if _state(ALL_ROOMS_USE_PYSCRIPT) == "on":
+            pys_val = _state(PYSCRIPT_BRIGHTNESS)
+            if pys_val not in invalid:
+                val = _clamp_pct(pys_val)
+                if val is not None:
+                    _info(f"Brightness source: PyScript Engine ({val}%)")
+                    return val
+
+        if _state(INTELLIGENT_LIGHTING_ENABLED) == "on":
+            intelligent = _state(INTELLIGENT_BRIGHTNESS)
+            if intelligent not in invalid:
+                val = _clamp_pct(intelligent)
+                if val is not None:
+                    _info(f"Brightness source: Intelligent System ({val}%)")
+                    return val
+
+    except Exception as exc:
+        _warn(f"Brightness resolution failed: {exc}")
+
+    fallback = _fallback_brightness_for(home_mode)
+    label = f"Fallback {home_mode}" if home_mode in FALLBACK_BRIGHTNESS else "Fallback Default"
+    _info(f"Brightness source: {label} ({fallback}%)")
+    return fallback
+
+
+def _night_mains_window_active(now=None) -> bool:
+    """Return True if mains may run while home state is Night."""
+    if now is None:
+        now = datetime.now()
+
+    hour = now.hour
+    minute = now.minute
+
+    if hour < NIGHT_MAIN_RESUME_HOUR:
+        return False
+    if hour == NIGHT_MAIN_RESUME_HOUR and minute < NIGHT_MAIN_RESUME_MINUTE:
+        return False
+    # Guard against late-night Night mode by requiring this to run before noon.
+    if hour >= 12:
+        return False
+
+    return True
+
 # --- core behavior ---
 def _apply_for_motion(active: bool, reason: str):
     hs = _home_state()
@@ -88,26 +187,33 @@ def _apply_for_motion(active: bool, reason: str):
 
     _info(f"APPLY motion_active={active} mode={hs} reason={reason}")
 
+    now = datetime.now()
+    night_mode = hs == "Night"
+    night_hold_active = night_mode and not _night_mains_window_active(now)
+
     if active:
         # WLEDs on preset night-100
         _set_preset(SINK_PRESET, "night-100")
         _set_preset(FRIDGE_PRESET, "night-100")
 
-        # Main lights ON - BUT NOT IN NIGHT MODE
-        if hs != "Night":
-            br = MAIN_BRIGHTNESS.get(hs, 50)
-            _light_on(KITCHEN_MAIN, brightness_pct=br)
+        if night_hold_active:
+            _info("SKIPPING main lights – Night mode hold active (pre-04:45)")
         else:
-            _info(f"SKIPPING main lights - Night mode (WLED only)")
+            if night_mode:
+                _info("Night resume window reached (>=04:45) – turning mains on")
+            br = _resolve_kitchen_brightness(hs if not night_mode else "Night")
+            _light_on(KITCHEN_MAIN, brightness_pct=br)
 
     else:
         # WLED behavior: sink OFF, fridge to night
         _light_off(SINK_LIGHT)
         _set_preset(FRIDGE_PRESET, "night")
 
-        # Main lights OFF if configured AND they were turned on (not in Night mode)
-        if TURN_MAIN_OFF_ON_CLEAR and hs != "Night":
-            _light_off(KITCHEN_MAIN)
+        if TURN_MAIN_OFF_ON_CLEAR:
+            if night_hold_active:
+                _info("Leaving main lights alone – Night hold still active")
+            else:
+                _light_off(KITCHEN_MAIN)
 
 # --- listeners (no YAML automation needed) ---
 @state_trigger(MOTION_1, state_check_now=False)
@@ -133,7 +239,7 @@ def kitchen_wled_smoke_test():
     _info("SMOKE: WLEDs -> night-100; mains on; then sink OFF, fridge -> night")
     _set_preset(SINK_PRESET, "night-100")
     _set_preset(FRIDGE_PRESET, "night-100")
-    _light_on(KITCHEN_MAIN, brightness_pct=MAIN_BRIGHTNESS.get("Evening", 60))
+    _light_on(KITCHEN_MAIN, brightness_pct=_fallback_brightness_for("Evening"))
     time.sleep(2)
     _light_off(SINK_LIGHT)
     _set_preset(FRIDGE_PRESET, "night")


### PR DESCRIPTION
## Summary
- compute the kitchen night hold state up front so motion clearly blocks the main lights before 04:45 while still driving the WLED presets
- reuse that hold flag on motion clear so the script leaves the mains untouched until the unlock window and continues to honor the controller brightness stack once unlocked

## Testing
- python -m compileall kitchen_motion.py "kitchen_motion(1).py"

------
https://chatgpt.com/codex/tasks/task_e_68cd8ab10270832cbe3a031ac2d868b1