### PR TITLE
Restrict kitchen WLEDs to evening/night modes

### DIFF
--- a/kitchen_motion(1).py
+++ b/kitchen_motion(1).py
@@ -20,7 +20,7 @@ MOTION_2      = "binary_sensor.kitchen_iris_frig_occupancy"
 HOME_STATE_PRIMARY = "pyscript.home_state"
 HOME_STATE_FALLBACK = "input_select.home_state"
 ALLOWED_MODES = {"Day", "Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
-WLED_BLOCKED_MODES = {"Day", "Away"}
+WLED_ALLOWED_MODES = {"Evening", "Night", "Early Morning"}
 NIGHT_MAIN_RESUME_HOUR = 4
 NIGHT_MAIN_RESUME_MINUTE = 45
 
@@ -189,7 +189,7 @@ def _ensure_wled_off(reason: str | None = None):
 def _apply_for_motion(active: bool, reason: str):
     hs = _home_state()
     if not TEST_BYPASS_MODE and hs not in ALLOWED_MODES:
-        if hs in WLED_BLOCKED_MODES:
+        if hs not in WLED_ALLOWED_MODES:
             _ensure_wled_off(f"mode={hs} disallows WLED (reason={reason})")
         _info(f"SKIP (mode={hs}) reason={reason}")
         return
@@ -202,7 +202,7 @@ def _apply_for_motion(active: bool, reason: str):
     if TEST_BYPASS_MODE:
         wled_allowed = True
     else:
-        wled_allowed = hs not in WLED_BLOCKED_MODES
+        wled_allowed = hs in WLED_ALLOWED_MODES
 
     if active:
         if wled_allowed:
@@ -256,7 +256,7 @@ async def kitchen_motion_listener(**kwargs):
 @state_trigger(HOME_STATE_FALLBACK)
 def kitchen_mode_change_guard(**kwargs):
     hs = _home_state()
-    if hs in {"Day", "Away"}:
+    if hs not in WLED_ALLOWED_MODES:
         _ensure_wled_off(f"home mode -> {hs}")
 
 # --- manual tests ---

--- a/kitchen_motion.py
+++ b/kitchen_motion.py
@@ -20,7 +20,7 @@ MOTION_2      = "binary_sensor.kitchen_iris_frig_occupancy"
 HOME_STATE_PRIMARY = "pyscript.home_state"
 HOME_STATE_FALLBACK = "input_select.home_state"
 ALLOWED_MODES = {"Day", "Evening", "Night", "Early Morning"}  # mains are NOT blocked in Evening
-WLED_BLOCKED_MODES = {"Day", "Away"}
+WLED_ALLOWED_MODES = {"Evening", "Night", "Early Morning"}
 NIGHT_MAIN_RESUME_HOUR = 4
 NIGHT_MAIN_RESUME_MINUTE = 45
 
@@ -190,7 +190,7 @@ def _ensure_wled_off(reason: str | None = None):
 def _apply_for_motion(active: bool, reason: str):
     hs = _home_state()
     if not TEST_BYPASS_MODE and hs not in ALLOWED_MODES:
-        if hs in WLED_BLOCKED_MODES:
+        if hs not in WLED_ALLOWED_MODES:
             _ensure_wled_off(f"mode={hs} disallows WLED (reason={reason})")
         _info(f"SKIP (mode={hs}) reason={reason}")
         return
@@ -203,7 +203,7 @@ def _apply_for_motion(active: bool, reason: str):
     if TEST_BYPASS_MODE:
         wled_allowed = True
     else:
-        wled_allowed = hs not in WLED_BLOCKED_MODES
+        wled_allowed = hs in WLED_ALLOWED_MODES
 
     if active:
         if wled_allowed:
@@ -257,7 +257,7 @@ async def kitchen_motion_listener(**kwargs):
 @state_trigger(HOME_STATE_FALLBACK)
 def kitchen_mode_change_guard(**kwargs):
     hs = _home_state()
-    if hs in {"Day", "Away"}:
+    if hs not in WLED_ALLOWED_MODES:
         _ensure_wled_off(f"home mode -> {hs}")
 
 # --- manual tests ---


### PR DESCRIPTION
## Summary
- add a helper and mode allow-list so the kitchen motion script only powers WLED strips in Evening, Night, or Early Morning
- turn both strips off whenever motion occurs in disallowed modes and when the home state shifts to Day or Away
- mirror the same WLED enforcement and home state guard in the legacy kitchen motion helper

## Testing
- python -m compileall kitchen_motion.py "kitchen_motion(1).py"

------
https://chatgpt.com/codex/tasks/task_e_68cd8ab10270832cbe3a031ac2d868b1