### PR TITLE
Add Node-RED flow for home mode engine

### DIFF
--- a/home_controller.py
+++ b/home_controller.py
@@ -1572,9 +1572,11 @@ def _publish_day_commit_and_target():
     """Publish day commit time and brightness target sensors"""
     commit = _compute_day_commit_time()
     if commit:
-        state.set("sensor.day_commit_time", commit.isoformat(sep=" "), {
-            "friendly_name": "Day Commit Time",
-        })
+        _set_sensor(
+            "sensor.day_commit_time",
+            commit.isoformat(sep=" "),
+            {"friendly_name": "Day Commit Time"},
+        )
         if _get("input_datetime.ramp_calculated_end_time") not in (None, "unavailable"):
             try:
                 service.call("input_datetime","set_datetime",
@@ -1583,18 +1585,23 @@ def _publish_day_commit_and_target():
             except Exception as e:
                 log.warning(f"[HC] Could not mirror commit time: {e}")
     else:
-        state.set("sensor.day_commit_time", "", {
-            "friendly_name": "Day Commit Time", 
-            "reason":"insufficient_inputs"
-        })
-    
+        _set_sensor(
+            "sensor.day_commit_time",
+            "",
+            {"friendly_name": "Day Commit Time", "reason": "insufficient_inputs"},
+        )
+
     bri, src = _resolve_day_target_brightness()
-    state.set("sensor.day_target_brightness", bri, {
-        "friendly_name": "Day Target Brightness",
-        "unit_of_measurement": "%",
-        "source": src,
-        "updated_at": _now().isoformat()
-    })
+    _set_sensor(
+        "sensor.day_target_brightness",
+        bri,
+        {
+            "friendly_name": "Day Target Brightness",
+            "unit_of_measurement": "%",
+            "source": src,
+            "updated_at": _now().isoformat(),
+        },
+    )
 
 # ============================================================================
 # NIGHT MODE - SET IN STONE

--- a/home_mode_engine_flow.json
+++ b/home_mode_engine_flow.json
@@ -1,0 +1,1699 @@
+[
+    {
+        "id": "a1b2c3d4.e5f6a7",
+        "type": "tab",
+        "label": "Home Mode Engine (Final Corrected)",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "e2f1b4d8.1d0e48",
+        "type": "group",
+        "z": "a1b2c3d4.e5f6a7",
+        "name": "SECTION 1: MQTT State Caching & Automatic Initialization",
+        "style": {
+            "stroke": "#999999",
+            "stroke-opacity": "1",
+            "fill": "none",
+            "fill-opacity": "1",
+            "label": true,
+            "label-position": "nw",
+            "color": "#999999"
+        },
+        "nodes": [
+            "mqtt_in_all",
+            "route_by_topic",
+            "save_current",
+            "save_flags",
+            "save_first_motion",
+            "startup_trigger",
+            "check_if_initialized",
+            "init_mode_payload",
+            "init_flags_payload",
+            "get_sun_state",
+            "0a893e4d177441e2"
+        ],
+        "x": 94,
+        "y": 19,
+        "w": 852,
+        "h": 282
+    },
+    {
+        "id": "c623d5d7.39dc28",
+        "type": "group",
+        "z": "a1b2c3d4.e5f6a7",
+        "name": "SECTION 2: Triggers That Propose a Mode Change",
+        "style": {
+            "stroke": "#999999",
+            "stroke-opacity": "1",
+            "fill": "none",
+            "fill-opacity": "1",
+            "label": true,
+            "label-position": "nw",
+            "color": "#999999"
+        },
+        "nodes": [
+            "kitchen_motion",
+            "is_first_motion_of_day",
+            "morning_time_window",
+            "workday_or_dayoff",
+            "propose_workday",
+            "propose_dayoff",
+            "day_promo_730",
+            "day_promo_sunrise",
+            "check_mode_for_day_promo",
+            "propose_day",
+            "evening_promo_sunset",
+            "check_mode_for_evening_promo",
+            "propose_evening",
+            "bedroom_tv_on",
+            "propose_night_tv_on",
+            "eleven_pm_check",
+            "lr_tv_off",
+            "get_lr_tv_state",
+            "after_11pm_gate",
+            "start_settle_timer",
+            "cancel_settle_timer",
+            "settle_timer",
+            "propose_night_timer",
+            "daily_rollover",
+            "is_sun_down",
+            "catchup_evening_mode_check",
+            "set_night_payload",
+            "clear_flags_payload",
+            "clear_motion_payload",
+            "4aa30b8b4e43d6df",
+            "375e7259c590e399",
+            "993d820619505ea0"
+        ],
+        "x": -6,
+        "y": 339,
+        "w": 892,
+        "h": 822
+    },
+    {
+        "id": "d049d11b.2fb4e",
+        "type": "group",
+        "z": "a1b2c3d4.e5f6a7",
+        "name": "SECTION 3: The Validation Hub (Single Gatekeeper for All Changes)",
+        "style": {
+            "stroke": "#999999",
+            "stroke-opacity": "1",
+            "fill": "none",
+            "fill-opacity": "1",
+            "label": true,
+            "label-position": "nw",
+            "color": "#999999"
+        },
+        "nodes": [
+            "validation_hub",
+            "validate_from_night",
+            "validate_from_wd_do",
+            "validate_from_day",
+            "validate_from_evening"
+        ],
+        "x": 934,
+        "y": 636.5,
+        "w": 472,
+        "h": 324.5
+    },
+    {
+        "id": "f5165846.0ae3b8",
+        "type": "group",
+        "z": "a1b2c3d4.e5f6a7",
+        "name": "SECTION 4: Commit & Publish to MQTT",
+        "style": {
+            "stroke": "#999999",
+            "stroke-opacity": "1",
+            "fill": "none",
+            "fill-opacity": "1",
+            "label": true,
+            "label-position": "nw",
+            "color": "#999999"
+        },
+        "nodes": [
+            "commit_new_mode",
+            "publish_new_mode",
+            "publish_new_flags",
+            "rbe",
+            "mqtt_out"
+        ],
+        "x": 944,
+        "y": 459,
+        "w": 762,
+        "h": 582
+    },
+    {
+        "id": "mqtt_in_all",
+        "type": "mqtt in",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "home/mode/#",
+        "topic": "home/mode/#",
+        "qos": "2",
+        "datatype": "auto",
+        "broker": "3d643dfa40d3c0f4",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 200,
+        "y": 80,
+        "wires": [
+            [
+                "route_by_topic"
+            ]
+        ]
+    },
+    {
+        "id": "route_by_topic",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Route by Topic",
+        "property": "topic",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "home/mode/current",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "home/mode/flags",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "home/mode/morning/first_motion",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 3,
+        "x": 410,
+        "y": 80,
+        "wires": [
+            [
+                "save_current"
+            ],
+            [
+                "save_flags"
+            ],
+            [
+                "save_first_motion"
+            ]
+        ]
+    },
+    {
+        "id": "save_current",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Save flow.current",
+        "rules": [
+            {
+                "t": "set",
+                "p": "current",
+                "pt": "flow",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 640,
+        "y": 60,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "save_flags",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Save flow.flags",
+        "rules": [
+            {
+                "t": "set",
+                "p": "flags",
+                "pt": "flow",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 630,
+        "y": 100,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "save_first_motion",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Save flow.first_motion",
+        "rules": [
+            {
+                "t": "set",
+                "p": "first_motion",
+                "pt": "flow",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 660,
+        "y": 140,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "startup_trigger",
+        "type": "inject",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "On Start (after 2s delay)",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": "2",
+        "topic": "",
+        "x": 250,
+        "y": 200,
+        "wires": [
+            [
+                "check_if_initialized"
+            ]
+        ]
+    },
+    {
+        "id": "check_if_initialized",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Is system initialized?",
+        "property": "current",
+        "propertyType": "flow",
+        "rules": [
+            {
+                "t": "istype",
+                "v": "undefined",
+                "vt": "undefined"
+            },
+            {
+                "t": "else"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 490,
+        "y": 200,
+        "wires": [
+            [
+                "init_mode_payload",
+                "init_flags_payload"
+            ],
+            [
+                "get_sun_state",
+                "0a893e4d177441e2"
+            ]
+        ]
+    },
+    {
+        "id": "init_mode_payload",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Create Default 'current' state",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "home/mode/current",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\t    \"date\": $substring($now(), 0, 10),\t    \"base_mode\": \"Night\"\t}",
+                "tot": "jsonata"
+            }
+        ],
+        "x": 780,
+        "y": 180,
+        "wires": [
+            [
+                "mqtt_out"
+            ]
+        ]
+    },
+    {
+        "id": "init_flags_payload",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Create Default 'flags' state",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "home/mode/flags",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\t    \"date\": $substring($now(), 0, 10),\t    \"workday\": \"\",\t    \"dayoff\": \"\",\t    \"day\": \"\",\t    \"evening\": \"\"\t}",
+                "tot": "jsonata"
+            }
+        ],
+        "x": 780,
+        "y": 220,
+        "wires": [
+            [
+                "mqtt_out"
+            ]
+        ]
+    },
+    {
+        "id": "get_sun_state",
+        "type": "api-current-state",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "Startup Reconciler: Get HA Sun State",
+        "server": "983f947e.e557a8",
+        "version": 3,
+        "outputs": 1,
+        "halt_if": "",
+        "halt_if_type": "str",
+        "halt_if_compare": "is",
+        "entity_id": "sun.sun",
+        "state_type": "str",
+        "blockInputOverrides": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            }
+        ],
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "x": 750,
+        "y": 260,
+        "wires": [
+            [
+                "is_sun_down",
+                "0a893e4d177441e2"
+            ]
+        ]
+    },
+    {
+        "id": "kitchen_motion",
+        "type": "server-state-changed",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "1. Morning: Kitchen Motion ON",
+        "server": "983f947e.e557a8",
+        "version": 6,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entities": {
+            "entity": [
+                "binary_sensor.aqara_motion_sensor_p1_occupancy"
+            ],
+            "substring": [],
+            "regex": []
+        },
+        "outputInitially": false,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "outputOnlyOnStateChange": false,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": true,
+        "ignorePrevStateUnknown": true,
+        "ignorePrevStateUnavailable": true,
+        "ignoreCurrentStateUnknown": true,
+        "ignoreCurrentStateUnavailable": true,
+        "outputProperties": [],
+        "x": 260,
+        "y": 380,
+        "wires": [
+            [
+                "is_first_motion_of_day"
+            ]
+        ]
+    },
+    {
+        "id": "is_first_motion_of_day",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Is first_motion empty?",
+        "property": "first_motion.branch",
+        "propertyType": "flow",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 510,
+        "y": 380,
+        "wires": [
+            [
+                "morning_time_window"
+            ]
+        ]
+    },
+    {
+        "id": "morning_time_window",
+        "type": "time-range-switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "04:50 to 07:30?",
+        "startTime": "04:50",
+        "endTime": "07:30",
+        "x": 510,
+        "y": 420,
+        "wires": [
+            [
+                "workday_or_dayoff"
+            ],
+            []
+        ]
+    },
+    {
+        "id": "workday_or_dayoff",
+        "type": "time-range-switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "< 05:00?",
+        "startTime": "00:00",
+        "endTime": "05:00",
+        "x": 500,
+        "y": 460,
+        "wires": [
+            [
+                "propose_workday"
+            ],
+            [
+                "propose_dayoff"
+            ]
+        ]
+    },
+    {
+        "id": "propose_workday",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Propose: Work Day",
+        "rules": [
+            {
+                "t": "set",
+                "p": "to",
+                "pt": "msg",
+                "to": "Work Day",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "why",
+                "pt": "msg",
+                "to": "first_motion_pre5",
+                "tot": "str"
+            }
+        ],
+        "x": 730,
+        "y": 440,
+        "wires": [
+            [
+                "validation_hub"
+            ]
+        ]
+    },
+    {
+        "id": "propose_dayoff",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Propose: Day Off",
+        "rules": [
+            {
+                "t": "set",
+                "p": "to",
+                "pt": "msg",
+                "to": "Day Off",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "why",
+                "pt": "msg",
+                "to": "first_motion_post5",
+                "tot": "str"
+            }
+        ],
+        "x": 730,
+        "y": 480,
+        "wires": [
+            [
+                "validation_hub"
+            ]
+        ]
+    },
+    {
+        "id": "day_promo_730",
+        "type": "schedex",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "2a. Day: 07:30",
+        "passthroughunhandled": false,
+        "suspended": false,
+        "lat": "40.37494",
+        "lon": "-79.81098",
+        "ontime": "07:30",
+        "ontopic": "",
+        "onpayload": "",
+        "onoffset": 0,
+        "onrandomoffset": 0,
+        "offtime": "",
+        "offtopic": "",
+        "offpayload": "",
+        "offoffset": 0,
+        "offrandomoffset": 0,
+        "mon": true,
+        "tue": true,
+        "wed": true,
+        "thu": true,
+        "fri": true,
+        "sat": true,
+        "sun": true,
+        "x": 220,
+        "y": 500,
+        "wires": [
+            [
+                "check_mode_for_day_promo"
+            ]
+        ]
+    },
+    {
+        "id": "day_promo_sunrise",
+        "type": "schedex",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "2b. Day: Sunrise (+30)",
+        "passthroughunhandled": false,
+        "suspended": false,
+        "lat": "40.37483",
+        "lon": "-79.81081",
+        "ontime": "sunrise",
+        "ontopic": "",
+        "onpayload": "",
+        "onoffset": 30,
+        "onrandomoffset": 0,
+        "offtime": "",
+        "offtopic": "",
+        "offpayload": "",
+        "offoffset": 0,
+        "offrandomoffset": 0,
+        "mon": true,
+        "tue": true,
+        "wed": true,
+        "thu": true,
+        "fri": true,
+        "sat": true,
+        "sun": true,
+        "x": 250,
+        "y": 580,
+        "wires": [
+            [
+                "check_mode_for_day_promo"
+            ]
+        ]
+    },
+    {
+        "id": "check_mode_for_day_promo",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Mode is WD/DO?",
+        "property": "current.base_mode",
+        "propertyType": "flow",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Work Day",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "Day Off",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 500,
+        "y": 560,
+        "wires": [
+            [
+                "propose_day"
+            ],
+            [
+                "propose_day"
+            ]
+        ]
+    },
+    {
+        "id": "propose_day",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Propose: Day",
+        "rules": [
+            {
+                "t": "set",
+                "p": "to",
+                "pt": "msg",
+                "to": "Day",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "why",
+                "pt": "msg",
+                "to": "schedex_day_promo",
+                "tot": "str"
+            }
+        ],
+        "x": 730,
+        "y": 560,
+        "wires": [
+            [
+                "validation_hub"
+            ]
+        ]
+    },
+    {
+        "id": "evening_promo_sunset",
+        "type": "schedex",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "3. Evening: Sunset (-30)",
+        "passthroughunhandled": false,
+        "suspended": false,
+        "lat": "40.37483",
+        "lon": "-79.81081",
+        "ontime": "sunset",
+        "ontopic": "",
+        "onpayload": "",
+        "onoffset": -30,
+        "onrandomoffset": 0,
+        "offtime": "",
+        "offtopic": "",
+        "offpayload": "",
+        "offoffset": 0,
+        "offrandomoffset": 0,
+        "mon": true,
+        "tue": true,
+        "wed": true,
+        "thu": true,
+        "fri": true,
+        "sat": true,
+        "sun": true,
+        "x": 250,
+        "y": 640,
+        "wires": [
+            [
+                "check_mode_for_evening_promo"
+            ]
+        ]
+    },
+    {
+        "id": "check_mode_for_evening_promo",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Mode is Day?",
+        "property": "current.base_mode",
+        "propertyType": "flow",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Day",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 480,
+        "y": 640,
+        "wires": [
+            [
+                "propose_evening",
+                "4aa30b8b4e43d6df",
+                "375e7259c590e399"
+            ]
+        ]
+    },
+    {
+        "id": "propose_evening",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Propose: Evening",
+        "rules": [
+            {
+                "t": "set",
+                "p": "to",
+                "pt": "msg",
+                "to": "Evening",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "why",
+                "pt": "msg",
+                "to": "schedex_evening_promo",
+                "tot": "str"
+            }
+        ],
+        "x": 710,
+        "y": 640,
+        "wires": [
+            [
+                "validation_hub",
+                "4aa30b8b4e43d6df"
+            ]
+        ]
+    },
+    {
+        "id": "bedroom_tv_on",
+        "type": "server-state-changed",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "4a. Night: Bedroom TV ON",
+        "server": "983f947e.e557a8",
+        "version": 6,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entities": {
+            "entity": [
+                "media_player.bedroom"
+            ],
+            "substring": [],
+            "regex": []
+        },
+        "outputInitially": false,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "outputOnlyOnStateChange": false,
+        "for": "",
+        "forType": "num",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [],
+        "x": 250,
+        "y": 720,
+        "wires": [
+            [
+                "propose_night_tv_on",
+                "cancel_settle_timer"
+            ]
+        ]
+    },
+    {
+        "id": "propose_night_tv_on",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Propose: Night (TV)",
+        "rules": [
+            {
+                "t": "set",
+                "p": "to",
+                "pt": "msg",
+                "to": "Night",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "why",
+                "pt": "msg",
+                "to": "bedroom_tv",
+                "tot": "str"
+            }
+        ],
+        "x": 490,
+        "y": 720,
+        "wires": [
+            [
+                "validation_hub",
+                "4aa30b8b4e43d6df"
+            ]
+        ]
+    },
+    {
+        "id": "eleven_pm_check",
+        "type": "inject",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "4b. Night: 23:00 Checkpoint",
+        "props": [],
+        "repeat": "",
+        "crontab": "00 23 * * *",
+        "once": false,
+        "topic": "",
+        "x": 250,
+        "y": 820,
+        "wires": [
+            [
+                "get_lr_tv_state"
+            ]
+        ]
+    },
+    {
+        "id": "lr_tv_off",
+        "type": "server-state-changed",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "4c. Night: LR TV turns OFF",
+        "server": "983f947e.e557a8",
+        "version": 6,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entities": {
+            "entity": [
+                "media_player.apple_tv_4k_livingroom"
+            ],
+            "substring": [],
+            "regex": []
+        },
+        "outputInitially": false,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "outputOnlyOnStateChange": false,
+        "for": "",
+        "forType": "num",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [],
+        "x": 250,
+        "y": 880,
+        "wires": [
+            [
+                "after_11pm_gate"
+            ]
+        ]
+    },
+    {
+        "id": "get_lr_tv_state",
+        "type": "api-current-state",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Get LR TV state",
+        "server": "983f947e.e557a8",
+        "version": 3,
+        "outputs": 2,
+        "halt_if": "off",
+        "halt_if_type": "str",
+        "halt_if_compare": "is",
+        "entity_id": "media_player.apple_tv_4k_livingroom",
+        "state_type": "str",
+        "blockInputOverrides": false,
+        "outputProperties": [],
+        "for": "",
+        "forType": "num",
+        "x": 490,
+        "y": 820,
+        "wires": [
+            [
+                "start_settle_timer"
+            ],
+            []
+        ]
+    },
+    {
+        "id": "after_11pm_gate",
+        "type": "time-range-switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "After 23:00?",
+        "startTime": "23:00",
+        "endTime": "03:00",
+        "x": 480,
+        "y": 880,
+        "wires": [
+            [
+                "start_settle_timer"
+            ],
+            []
+        ]
+    },
+    {
+        "id": "start_settle_timer",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "start",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "start",
+                "tot": "str"
+            }
+        ],
+        "x": 490,
+        "y": 850,
+        "wires": [
+            [
+                "settle_timer"
+            ]
+        ]
+    },
+    {
+        "id": "cancel_settle_timer",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "reset",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "reset",
+                "tot": "str"
+            }
+        ],
+        "x": 470,
+        "y": 760,
+        "wires": [
+            [
+                "settle_timer"
+            ]
+        ]
+    },
+    {
+        "id": "settle_timer",
+        "type": "trigger",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "30 Min Settle Timer",
+        "op1": "start",
+        "op2": "",
+        "op1type": "str",
+        "op2type": "nul",
+        "duration": "30",
+        "extend": false,
+        "overrideDelay": false,
+        "units": "min",
+        "reset": "reset",
+        "bytopic": "all",
+        "topic": "topic",
+        "outputs": 1,
+        "x": 620,
+        "y": 850,
+        "wires": [
+            [
+                "propose_night_timer"
+            ]
+        ]
+    },
+    {
+        "id": "propose_night_timer",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Propose: Night (Timer)",
+        "rules": [
+            {
+                "t": "set",
+                "p": "to",
+                "pt": "msg",
+                "to": "Night",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "why",
+                "pt": "msg",
+                "to": "lr_off_timer",
+                "tot": "str"
+            }
+        ],
+        "x": 630,
+        "y": 910,
+        "wires": [
+            [
+                "validation_hub"
+            ]
+        ]
+    },
+    {
+        "id": "daily_rollover",
+        "type": "inject",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "5. Rollover: 3:00 AM Daily",
+        "props": [],
+        "repeat": "",
+        "crontab": "00 03 * * *",
+        "once": false,
+        "topic": "",
+        "x": 240,
+        "y": 1060,
+        "wires": [
+            [
+                "set_night_payload",
+                "clear_flags_payload",
+                "clear_motion_payload"
+            ]
+        ]
+    },
+    {
+        "id": "is_sun_down",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Is sun below_horizon?",
+        "property": "payload",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "below_horizon",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 480,
+        "y": 980,
+        "wires": [
+            [
+                "catchup_evening_mode_check"
+            ]
+        ]
+    },
+    {
+        "id": "catchup_evening_mode_check",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Mode is Day?",
+        "property": "current.base_mode",
+        "propertyType": "flow",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Day",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 700,
+        "y": 980,
+        "wires": [
+            [
+                "propose_evening",
+                "4aa30b8b4e43d6df"
+            ]
+        ]
+    },
+    {
+        "id": "set_night_payload",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Set mode to Night",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "home/mode/current",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\t    \"date\": $substring($now(), 0, 10),\t    \"base_mode\": \"Night\"\t}",
+                "tot": "jsonata"
+            }
+        ],
+        "x": 500,
+        "y": 1040,
+        "wires": [
+            [
+                "rbe"
+            ]
+        ]
+    },
+    {
+        "id": "clear_flags_payload",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Clear daily flags",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "home/mode/flags",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\t    \"date\": $substring($now(), 0, 10),\t    \"workday\": \"\",\t    \"dayoff\": \"\",\t    \"day\": \"\",\t    \"evening\": \"\"\t}",
+                "tot": "jsonata"
+            }
+        ],
+        "x": 500,
+        "y": 1080,
+        "wires": [
+            [
+                "rbe"
+            ]
+        ]
+    },
+    {
+        "id": "clear_motion_payload",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "Clear first_motion",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "home/mode/morning/first_motion",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\t    \"date\": $substring($now(), 0, 10),\t    \"timestamp\": \"\",\t    \"window\": \"\",\t    \"branch\": \"\"\t}",
+                "tot": "jsonata"
+            }
+        ],
+        "x": 510,
+        "y": 1120,
+        "wires": [
+            [
+                "rbe"
+            ]
+        ]
+    },
+    {
+        "id": "validation_hub",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "d049d11b.2fb4e",
+        "name": "VALIDATE: Current Mode?",
+        "property": "current.base_mode",
+        "propertyType": "flow",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Night",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "Work Day",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "Day Off",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "Day",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "Evening",
+                "vt": "str"
+            }
+        ],
+        "checkall": "false",
+        "repair": false,
+        "outputs": 5,
+        "x": 1080,
+        "y": 700,
+        "wires": [
+            [
+                "validate_from_night"
+            ],
+            [
+                "validate_from_wd_do"
+            ],
+            [
+                "validate_from_wd_do"
+            ],
+            [
+                "validate_from_day"
+            ],
+            [
+                "validate_from_evening"
+            ]
+        ]
+    },
+    {
+        "id": "validate_from_night",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "d049d11b.2fb4e",
+        "name": "To WD or DO?",
+        "property": "to",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Work Day",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "Day Off",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 1300,
+        "y": 740,
+        "wires": [
+            [
+                "commit_new_mode"
+            ],
+            [
+                "commit_new_mode"
+            ]
+        ]
+    },
+    {
+        "id": "validate_from_wd_do",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "d049d11b.2fb4e",
+        "name": "To Day?",
+        "property": "to",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Day",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 1310,
+        "y": 800,
+        "wires": [
+            [
+                "commit_new_mode"
+            ]
+        ]
+    },
+    {
+        "id": "validate_from_day",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "d049d11b.2fb4e",
+        "name": "To Evening?",
+        "property": "to",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Evening",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 1310,
+        "y": 860,
+        "wires": [
+            [
+                "commit_new_mode"
+            ]
+        ]
+    },
+    {
+        "id": "validate_from_evening",
+        "type": "switch",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "d049d11b.2fb4e",
+        "name": "To Night?",
+        "property": "to",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Night",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 1310,
+        "y": 920,
+        "wires": [
+            [
+                "commit_new_mode"
+            ]
+        ]
+    },
+    {
+        "id": "commit_new_mode",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "f5165846.0ae3b8",
+        "name": "COMMIT: Set Payloads",
+        "rules": [
+            {
+                "t": "set",
+                "p": "new_mode_payload",
+                "pt": "msg",
+                "to": "{\t    \"date\": $substring($now(), 0, 10),\t    \"base_mode\": msg.to\t}",
+                "tot": "jsonata"
+            },
+            {
+                "t": "set",
+                "p": "new_flags_payload",
+                "pt": "msg",
+                "to": "$merge([\t    $flowContext('flags'),\t    {\t        (msg.to.lower().replace(\" \", \"\")): $substring($now(), 0, 10)\t    }\t])",
+                "tot": "jsonata"
+            }
+        ],
+        "x": 1080,
+        "y": 980,
+        "wires": [
+            [
+                "publish_new_mode",
+                "publish_new_flags"
+            ]
+        ]
+    },
+    {
+        "id": "publish_new_mode",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "f5165846.0ae3b8",
+        "name": "Prep 'current' message",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "home/mode/current",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "new_mode_payload",
+                "tot": "msg"
+            }
+        ],
+        "x": 1350,
+        "y": 960,
+        "wires": [
+            [
+                "rbe"
+            ]
+        ]
+    },
+    {
+        "id": "publish_new_flags",
+        "type": "change",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "f5165846.0ae3b8",
+        "name": "Prep 'flags' message",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "home/mode/flags",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "new_flags_payload",
+                "tot": "msg"
+            }
+        ],
+        "x": 1340,
+        "y": 1000,
+        "wires": [
+            [
+                "rbe"
+            ]
+        ]
+    },
+    {
+        "id": "rbe",
+        "type": "rbe",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "f5165846.0ae3b8",
+        "name": "Block Duplicates",
+        "func": "rbe",
+        "gap": "",
+        "start": "",
+        "inout": "out",
+        "septopics": true,
+        "property": "payload",
+        "x": 1580,
+        "y": 500,
+        "wires": [
+            [
+                "mqtt_out"
+            ]
+        ]
+    },
+    {
+        "id": "mqtt_out",
+        "type": "mqtt out",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "f5165846.0ae3b8",
+        "name": "MQTT Out (retain)",
+        "topic": "",
+        "qos": "2",
+        "retain": "true",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "3d643dfa40d3c0f4",
+        "x": 1590,
+        "y": 560,
+        "wires": []
+    },
+    {
+        "id": "4aa30b8b4e43d6df",
+        "type": "debug",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "debug 3",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 780,
+        "y": 700,
+        "wires": []
+    },
+    {
+        "id": "0a893e4d177441e2",
+        "type": "debug",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "e2f1b4d8.1d0e48",
+        "name": "debug 7",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 840,
+        "y": 100,
+        "wires": []
+    },
+    {
+        "id": "375e7259c590e399",
+        "type": "debug",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "debug 8",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 680,
+        "y": 940,
+        "wires": []
+    },
+    {
+        "id": "993d820619505ea0",
+        "type": "inject",
+        "z": "a1b2c3d4.e5f6a7",
+        "g": "c623d5d7.39dc28",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 100,
+        "y": 680,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "3d643dfa40d3c0f4",
+        "type": "mqtt-broker",
+        "name": "",
+        "broker": "192.168.10.199",
+        "port": "1883",
+        "clientid": "",
+        "autoConnect": true,
+        "usetls": false,
+        "protocolVersion": "4",
+        "keepalive": "60",
+        "cleansession": true,
+        "autoUnsubscribe": true,
+        "birthTopic": "",
+        "birthQos": "0",
+        "birthRetain": "false",
+        "birthPayload": "",
+        "birthMsg": {},
+        "closeTopic": "",
+        "closeQos": "0",
+        "closeRetain": "false",
+        "closePayload": "",
+        "closeMsg": {},
+        "willTopic": "",
+        "willQos": "0",
+        "willRetain": "false",
+        "willPayload": "",
+        "willMsg": {},
+        "userProps": "",
+        "sessionExpiry": ""
+    },
+    {
+        "id": "983f947e.e557a8",
+        "type": "server",
+        "name": "Home Assistant",
+        "version": 5,
+        "addon": true,
+        "rejectUnauthorizedCerts": true,
+        "ha_boolean": "y|yes|true|on|home|open",
+        "connectionDelay": true,
+        "cacheJson": true,
+        "heartbeat": false,
+        "heartbeatInterval": "30",
+        "areaSelector": "friendlyName",
+        "deviceSelector": "friendlyName",
+        "entitySelector": "friendlyName",
+        "statusSeparator": "at: ",
+        "statusYear": "hidden",
+        "statusMonth": "short",
+        "statusDay": "numeric",
+        "statusHourCycle": "h23",
+        "statusTimeFormat": "h:m",
+        "enableGlobalContextStore": true
+    }
+]


### PR DESCRIPTION
## Summary
- add a Node-RED export of the Home Mode Engine flow so it can be imported directly into Node-RED

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d756097cf8832c9ffe0e78c0a02f62